### PR TITLE
update to Pretender v0.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,8 @@
     "tests"
   ],
   "dependencies": {
-    "pretender": "~0.0.6",
-    "dorante": "~0.2.0",
+    "pretender": "0.6.0",
+    "dorante": "~0.3.0",
     "jquery": "~2.1.1"
   },
   "devDependencies": {

--- a/geronte.js
+++ b/geronte.js
@@ -92,7 +92,7 @@
         { 'Content-Type': 'application/json' },
         JSON.stringify(body)
       ];
-    });
+    }, false);
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geronte",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Takes a JSON schema and uses Dorante and Pretender to create a client-side-only stub of an API",
   "main": "geronte.js",
   "scripts": {


### PR DESCRIPTION
Pretender v0.5.0 introduced `timing` which defaults to async; this PR updated to v0.6 and explicitly opts-in to [synchronous timing](https://github.com/trek/pretender#timing-parameter).