### PR TITLE
Allow dynamic route matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.0 - 24th July 2015
+
+- Allow dynamic segments in path expectations.
+
 # v0.3.0 - 20rd November 2014
 
 - Allow Expectation#when to accept a callback.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ geronte.done();
 // throws an error if POST /foo didn't happen
 ```
 
+Dynamic segments are supported for paths:
+```js
+geronte.expect('POST', '/foo/:id');
+// do stuff
+geronte.done();
+// throws an error if POST /foo/anything didn't happen
+```
+
 Expectations can be made against request headers, body and form data:
 
 ```js

--- a/bower.json
+++ b/bower.json
@@ -24,10 +24,14 @@
   "dependencies": {
     "pretender": "0.6.0",
     "dorante": "~0.3.0",
-    "jquery": "~2.1.1"
+    "jquery": "~2.1.1",
+    "route-recognizer": "~0.1.9"
   },
   "devDependencies": {
     "fetch": "~0.2.1",
     "es6-promise": "~1.0.0"
+  },
+  "resolutions": {
+    "FakeXMLHttpRequest": "~1.0.0"
   }
 }

--- a/geronte.js
+++ b/geronte.js
@@ -152,7 +152,7 @@
    * @class Expectation
    * @constructor
    * @param {String} method the HTTP verb to expect
-   * @param {String} pathname the pathname to expect
+   * @param {String|Regex} pathname the expected pathname
    */
   function Expectation(method, pathname) {
     this.callback = function noop() {};
@@ -191,7 +191,10 @@
    * @param req {jqXHR} representing a request
    */
   Expectation.prototype.isFulfilledBy = function geronteIsFulfilledBy(req) {
-    var matchesPath    = (req.url === this.pathname);
+    var router = new global.RouteRecognizer();
+    router.add([{ path: this.pathname }]);
+
+    var matchesPath    = !!router.recognize(req.url);
     var matchesMethod  = (req.method === this.method);
     var matchesHeaders = compareObjects(this.headers, req.requestHeaders);
     var matchesBody    = (this.body == null || this.body === req.requestBody);

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "karma-cli": "0.0.4",
     "karma-jasmine": "^0.2.0",
     "karma-phantomjs-launcher": "^0.1.4"
+  },
+  "dependencies": {
+    "route-recognizer": "^0.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geronte",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Takes a JSON schema and uses Dorante and Pretender to create a client-side-only stub of an API",
   "main": "geronte.js",
   "scripts": {

--- a/test/expectation-test.js
+++ b/test/expectation-test.js
@@ -77,6 +77,19 @@ describe('Geronte.Expectation', function() {
         expect(result).toBe(false);
       });
 
+      describe('with a dynamic path', function() {
+        beforeEach(function() {
+          expectation = new Geronte.Expectation('GET', '/foo/:id');
+        });
+
+        it('is true when passed a matching request', function() {
+          var result = expectation.isFulfilledBy({
+            method: 'GET',
+            url: '/foo/123' });
+          expect(result).toBe(true);
+        });
+      });
+
       describe('and headers', function() {
         beforeEach(function() {
           expectation.with({


### PR DESCRIPTION
Allows expectations like:

```js
server.expect('GET', '/bar/:id');
// Matches GET /bar/123
```

This matches up with the behaviour or `Geronte#createStub` by using the same route recognizer lib as Pretender.